### PR TITLE
Check type equality in assert equals

### DIFF
--- a/assertions.go
+++ b/assertions.go
@@ -11,9 +11,9 @@ type Assertion struct {
 }
 
 func objectsAreEqual(a, b interface{}) bool {
-  if reflect.TypeOf(a) != reflect.TypeOf(b) {
-    return false
-  }
+	if reflect.TypeOf(a) != reflect.TypeOf(b) {
+		return false
+	}
 
 	if reflect.DeepEqual(a, b) {
 		return true

--- a/assertions_test.go
+++ b/assertions_test.go
@@ -9,70 +9,69 @@ type String string
 
 // Helper for testing Assertion conditions
 type AssertionVerifier struct {
-  ShouldPass bool
-  didFail    bool
+	ShouldPass bool
+	didFail    bool
 }
 
 func (a *AssertionVerifier) FailFunc(msg interface{}) {
-  a.didFail = true
+	a.didFail = true
 }
 
 func (a *AssertionVerifier) Verify(t *testing.T) {
-  if a.didFail == a.ShouldPass {
-    t.FailNow()
-  }
+	if a.didFail == a.ShouldPass {
+		t.FailNow()
+	}
 }
 
 func TestEqual(t *testing.T) {
 
-  verifier := AssertionVerifier{ShouldPass: true}
+	verifier := AssertionVerifier{ShouldPass: true}
 	a := Assertion{src: 1, fail: verifier.FailFunc}
 	a.Equal(1)
-  verifier.Verify(t)
+	verifier.Verify(t)
 	a.Eql(1)
-  verifier.Verify(t)
+	verifier.Verify(t)
 
 	a = Assertion{src: "foo"}
 	a.Equal("foo")
-  verifier.Verify(t)
+	verifier.Verify(t)
 	a.Eql("foo")
-  verifier.Verify(t)
-
+	verifier.Verify(t)
 
 	a = Assertion{src: map[string]string{"foo": "bar"}}
 	a.Equal(map[string]string{"foo": "bar"})
-  verifier.Verify(t)
+	verifier.Verify(t)
 	a.Eql(map[string]string{"foo": "bar"})
-  verifier.Verify(t)
+	verifier.Verify(t)
 
-  verifier = AssertionVerifier{ShouldPass: false}
-  a = Assertion{src: String("baz"), fail: verifier.FailFunc}
-  a.Equal("baz")
-  verifier.Verify(t)
-  a.Eql("baz")
-  verifier.Verify(t)
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: String("baz"), fail: verifier.FailFunc}
+	a.Equal("baz")
+	verifier.Verify(t)
+	a.Eql("baz")
+	verifier.Verify(t)
 }
 
 func TestIsTrue(t *testing.T) {
-  verifier := AssertionVerifier{ShouldPass: true}
+	verifier := AssertionVerifier{ShouldPass: true}
 	a := Assertion{src: true, fail: verifier.FailFunc}
 	a.IsTrue()
-  verifier.Verify(t)
+	verifier.Verify(t)
 
-  verifier = AssertionVerifier{ShouldPass: false}
-  a = Assertion{src: false, fail: verifier.FailFunc}
-  a.IsTrue()
-  verifier.Verify(t)
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: false, fail: verifier.FailFunc}
+	a.IsTrue()
+	verifier.Verify(t)
 }
 
 func TestIsFalse(t *testing.T) {
-  verifier := AssertionVerifier{ShouldPass: true}
+	verifier := AssertionVerifier{ShouldPass: true}
 	a := Assertion{src: false, fail: verifier.FailFunc}
 	a.IsFalse()
-  verifier.Verify(t)
+	verifier.Verify(t)
 
-  verifier = AssertionVerifier{ShouldPass: false}
-  a = Assertion{src: true, fail: verifier.FailFunc}
-  a.IsFalse()
-  verifier.Verify(t)
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: true, fail: verifier.FailFunc}
+	a.IsFalse()
+	verifier.Verify(t)
 }


### PR DESCRIPTION
Small bug in that type aliases don't get validated in reflect.DeepEquals and may therefore pass an Equals assertion.
