### PR TITLE
Added more power to Assert

### DIFF
--- a/assertions.go
+++ b/assertions.go
@@ -9,6 +9,7 @@ import (
 type Assertion struct {
 	src  interface{}
 	fail func(interface{})
+	Not  *NotAssertion
 }
 
 func objectsAreEqual(a, b interface{}) bool {
@@ -34,26 +35,77 @@ func formatMessages(messages ...string) string {
 	return ""
 }
 
-func (a *Assertion) Eql(dst interface{}) {
-	a.Equal(dst)
+func (a *Assertion) Eql(dst interface{}, messages ...string) {
+	a.Equal(dst, messages...)
 }
 
-func (a *Assertion) Equal(dst interface{}) {
+func (a *Assertion) Equal(dst interface{}, messages ...string) {
 	if !objectsAreEqual(a.src, dst) {
-		a.fail(fmt.Sprintf("%v %s %v", a.src, "does not equal", dst))
+		a.fail(fmt.Sprintf("%v does not equal %v%s", a.src, dst, formatMessages(messages...)))
 	}
 }
 
 func (a *Assertion) IsTrue(messages ...string) {
 	if !objectsAreEqual(a.src, true) {
-		message := fmt.Sprintf("%v %s%s", a.src, "expected false to be truthy", formatMessages(messages...))
-		a.fail(message)
+		a.fail(fmt.Sprintf("Expected %v to be truthy%s", a.src, formatMessages(messages...)))
 	}
 }
 
 func (a *Assertion) IsFalse(messages ...string) {
 	if !objectsAreEqual(a.src, false) {
-		message := fmt.Sprintf("%v %s%s", a.src, "expected true to be falsey", formatMessages(messages...))
-		a.fail(message)
+		a.fail(fmt.Sprintf("Expected %v to be falsey%s", a.src, formatMessages(messages...)))
+	}
+}
+
+func (a *Assertion) IsOK(messages ...string) {
+	if objectsAreEqual(a.src, nil) {
+		a.fail(fmt.Sprintf("Expected %v to be OK%s", a.src, formatMessages(messages...)))
+	}
+}
+
+func (a *Assertion) HasSameType(dst interface{}, messages ...string) {
+	if reflect.TypeOf(a.src) != reflect.TypeOf(dst) {
+		a.fail(fmt.Sprintf("%v is not the same type as %v%s", a.src, dst, formatMessages(messages...)))
+	}
+
+}
+
+type NotAssertion struct {
+	src  interface{}
+	fail func(interface{})
+	Not  *Assertion
+}
+
+func (n *NotAssertion) Eql(dst interface{}, messages ...string) {
+	n.Equal(dst, messages...)
+}
+
+func (n *NotAssertion) Equal(dst interface{}, messages ...string) {
+	if objectsAreEqual(n.src, dst) {
+		n.fail(fmt.Sprintf("Expected %v to not equal %v%s", n.src, dst, formatMessages(messages...)))
+	}
+}
+
+func (n *NotAssertion) IsTrue(messages ...string) {
+	if objectsAreEqual(n.src, true) {
+		n.fail(fmt.Sprintf("Expected %v to not be truthy%s", n.src, formatMessages(messages...)))
+	}
+}
+
+func (n *NotAssertion) IsFalse(messages ...string) {
+	if objectsAreEqual(n.src, false) {
+		n.fail(fmt.Sprintf("Expected %v to not be falsey%s", n.src, formatMessages(messages...)))
+	}
+}
+
+func (n *NotAssertion) IsOK(messages ...string) {
+	if !objectsAreEqual(n.src, nil) {
+		n.fail(fmt.Sprintf("Expected %v to not be OK%s", n.src, formatMessages(messages...)))
+	}
+}
+
+func (n *NotAssertion) HasSameType(dst interface{}, messages ...string) {
+	if reflect.TypeOf(n.src) == reflect.TypeOf(dst) {
+		n.fail(fmt.Sprintf("Expected %v to not be the same type as %v%s", n.src, dst, formatMessages(messages...)))
 	}
 }

--- a/tlf-custom_test.go
+++ b/tlf-custom_test.go
@@ -1,0 +1,136 @@
+package goblin
+
+import (
+	"testing"
+)
+
+func Testtlf(tes *testing.T) {
+	g := Goblin(tes)
+
+	g.Describe("Catching", func() {
+		g.It("No panic", func() {
+		})
+
+		g.It("Expected panic", func() {
+			g.ExpectPanic()
+			panic("Expect")
+		})
+
+		g.It("Fail on no expected panic", func() {
+			g.ExpectFail()
+			g.ExpectPanic()
+		})
+
+		g.It("Fail on unexpected panic", func() {
+			g.ExpectFail()
+			panic("Suddenly, panicing!")
+		})
+	})
+
+	g.Describe("Custom goblin assert", func() {
+		g.Describe("Working", func() {
+			g.Describe("Normal", func() {
+				g.It("Eql", func() {
+					g.Assert("Hello").Eql("Hello")
+				})
+
+				g.It("IsTrue", func() {
+					g.Assert(true).IsTrue()
+				})
+
+				g.It("IsFalse", func() {
+					g.Assert(false).IsFalse()
+				})
+
+				g.It("IsOK", func() {
+					g.Assert(g).IsOK()
+				})
+
+				g.It("IsType", func() {
+					g.Assert("").HasSameType("")
+				})
+			})
+
+			g.Describe("Not", func() {
+				g.It("Eql", func() {
+					g.Assert("Hello").Not.Eql("Lol")
+					g.Assert("Hello").Not.Eql("hello")
+				})
+
+				g.It("IsTrue", func() {
+					g.Assert(false).Not.IsTrue()
+					g.Assert("").Not.IsTrue()
+				})
+
+				g.It("IsFalse", func() {
+					g.Assert(true).Not.IsFalse()
+					g.Assert("a").Not.IsFalse()
+				})
+
+				g.It("IsOK", func() {
+					g.Assert(nil).Not.IsOK()
+				})
+
+				g.It("IsType", func() {
+					g.Assert(1).Not.HasSameType("")
+				})
+			})
+		})
+
+		g.Describe("Failing", func() {
+			g.Describe("Normal", func() {
+				g.It("Eql", func() {
+					g.ExpectFail()
+					g.Assert("Hello").Eql("hello")
+				})
+
+				g.It("IsTrue", func() {
+					g.ExpectFail()
+					g.Assert(false).IsTrue()
+				})
+
+				g.It("IsFalse", func() {
+					g.ExpectFail()
+					g.Assert(true).IsFalse()
+				})
+
+				g.It("IsOK", func() {
+					g.ExpectFail()
+					g.Assert(nil).IsOK()
+				})
+
+				g.It("IsType", func() {
+					g.ExpectFail()
+					g.Assert(1).HasSameType("")
+				})
+			})
+
+			g.Describe("Not", func() {
+				g.It("Eql", func() {
+					g.ExpectFail()
+					g.Assert("Hello").Not.Eql("Hello")
+				})
+
+				g.It("IsTrue", func() {
+					g.ExpectFail()
+					g.Assert(true).Not.IsTrue()
+				})
+
+				g.It("IsFalse", func() {
+					g.ExpectFail()
+					g.Assert(false).Not.IsFalse()
+				})
+
+				g.It("IsOK", func() {
+					g.ExpectFail()
+					g.Assert(g).Not.IsOK()
+				})
+
+				g.It("IsType", func() {
+					g.ExpectFail()
+					g.Assert("").Not.HasSameType("")
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
List of changes:
* assertions.go:
  * Added `not` functionality
  * Added IsOK method
  * Added IsSameType method
  * Cleaned up useless variable declarations
* goblin.go:
  * Added ExpectFail method - this allows for testing of failing methods
  * Added catch method - this will catch all panics thrown in an `It` block, and fail cleanly
  * Added ExpectPanic method - this will prevent the catch method causing a fail if it catches a panic, but will fail if the catch method does not catch a panic
* tlf-custom_test.go: (feel free to change that name)
  * Added tests for new items