### PR TITLE
Type assertion message

### DIFF
--- a/assertions_test.go
+++ b/assertions_test.go
@@ -58,6 +58,20 @@ func TestEqual(t *testing.T) {
 	verifier.Verify(t)
 	a.Eql("baz")
 	verifier.Verify(t)
+
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: String("baz"), fail: verifier.FailFunc}
+	a.Equal([]byte("baz"))
+	verifier.Verify(t)
+	a.Eql([]byte("baz"))
+	verifier.Verify(t)
+
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: int64(1), fail: verifier.FailFunc}
+	a.Equal(1)
+	verifier.Verify(t)
+	a.Eql(1)
+	verifier.Verify(t)
 }
 
 func TestIsTrue(t *testing.T) {


### PR DESCRIPTION
Some type errors appear to be the same value when using `%#v`.

For example:
```
g.Assert(int64(1)).Equal(1)
```

This will currently produce the error message: `1 does not equal 1`

This commit would change that message to: `int64(1) does not equal int(1)`