### PR TITLE
Allow other packages to implement Reporter

### DIFF
--- a/goblin.go
+++ b/goblin.go
@@ -106,9 +106,9 @@ func (d *Describe) run(g *G) bool {
 }
 
 type Failure struct {
-	stack    []string
-	testName string
-	message  string
+	Stack    []string
+	TestName string
+	Message  string
 }
 
 type It struct {
@@ -149,7 +149,7 @@ func (it *It) run(g *G) bool {
 }
 
 func (it *It) failed(msg string, stack []string) {
-	it.failure = &Failure{stack: stack, message: msg, testName: it.parent.name + " " + it.name}
+	it.failure = &Failure{Stack: stack, Message: msg, TestName: it.parent.name + " " + it.name}
 }
 
 type Xit struct {

--- a/goblin.go
+++ b/goblin.go
@@ -35,11 +35,11 @@ func (g *G) Describe(name string, h func()) {
 	g.parent = d.parent
 
 	if g.parent == nil && d.hasTests {
-		g.reporter.begin()
+		g.reporter.Begin()
 		if d.run(g) {
 			g.t.Fail()
 		}
-		g.reporter.end()
+		g.reporter.End()
 	}
 }
 func (g *G) Timeout(time time.Duration) {
@@ -83,7 +83,7 @@ func (d *Describe) runAfterEach() {
 func (d *Describe) run(g *G) bool {
 	failed := false
 	if d.hasTests {
-		g.reporter.beginDescribe(d.name)
+		g.reporter.BeginDescribe(d.name)
 
 		for _, b := range d.befores {
 			b()
@@ -99,7 +99,7 @@ func (d *Describe) run(g *G) bool {
 			a()
 		}
 
-		g.reporter.endDescribe()
+		g.reporter.EndDescribe()
 	}
 
 	return failed
@@ -124,7 +124,7 @@ func (it *It) run(g *G) bool {
 	g.currentIt = it
 
 	if it.h == nil {
-		g.reporter.itIsPending(it.name)
+		g.reporter.ItIsPending(it.name)
 		return false
 	}
 	//TODO: should handle errors for beforeEach
@@ -140,10 +140,10 @@ func (it *It) run(g *G) bool {
 	}
 
 	if failed {
-		g.reporter.itFailed(it.name)
-		g.reporter.failure(it.failure)
+		g.reporter.ItFailed(it.name)
+		g.reporter.Failure(it.failure)
 	} else {
-		g.reporter.itPassed(it.name)
+		g.reporter.ItPassed(it.name)
 	}
 	return failed
 }
@@ -164,7 +164,7 @@ type Xit struct {
 func (xit *Xit) run(g *G) bool {
 	g.currentIt = xit
 
-	g.reporter.itIsExcluded(xit.name)
+	g.reporter.ItIsExcluded(xit.name)
 	return false
 }
 
@@ -316,7 +316,7 @@ func (g *G) Assert(src interface{}) *Assertion {
 }
 
 func timeTrack(start time.Time, g *G) {
-	g.reporter.itTook(time.Since(start))
+	g.reporter.ItTook(time.Since(start))
 }
 
 func (g *G) Fail(error interface{}) {

--- a/reporting.go
+++ b/reporting.go
@@ -8,16 +8,16 @@ import (
 )
 
 type Reporter interface {
-	beginDescribe(string)
-	endDescribe()
-	begin()
-	end()
-	failure(*Failure)
-	itTook(time.Duration)
-	itFailed(string)
-	itPassed(string)
-	itIsPending(string)
-	itIsExcluded(string)
+	BeginDescribe(string)
+	EndDescribe()
+	Begin()
+	End()
+	Failure(*Failure)
+	ItTook(time.Duration)
+	ItFailed(string)
+	ItPassed(string)
+	ItIsPending(string)
+	ItIsExcluded(string)
 }
 
 type TextFancier interface {
@@ -71,7 +71,7 @@ func (r *DetailedReporter) getSpace() string {
 	return strings.Repeat(" ", (r.level+1)*2)
 }
 
-func (r *DetailedReporter) failure(failure *Failure) {
+func (r *DetailedReporter) Failure(failure *Failure) {
 	r.failures = append(r.failures, failure)
 }
 
@@ -83,45 +83,45 @@ func (r *DetailedReporter) printWithCheck(text string) {
 	fmt.Printf("%v%v\n", r.getSpace(), r.fancy.WithCheck(text))
 }
 
-func (r *DetailedReporter) beginDescribe(name string) {
+func (r *DetailedReporter) BeginDescribe(name string) {
 	fmt.Println("")
 	r.print(name)
 	r.level++
 }
 
-func (r *DetailedReporter) endDescribe() {
+func (r *DetailedReporter) EndDescribe() {
 	r.level--
 }
 
-func (r *DetailedReporter) itTook(duration time.Duration) {
+func (r *DetailedReporter) ItTook(duration time.Duration) {
 	r.executionTime = duration
 	r.totalExecutionTime += duration
 }
 
-func (r *DetailedReporter) itFailed(name string) {
+func (r *DetailedReporter) ItFailed(name string) {
 	r.failed++
 	r.print(r.fancy.Red(strconv.Itoa(r.failed) + ") " + name))
 }
 
-func (r *DetailedReporter) itPassed(name string) {
+func (r *DetailedReporter) ItPassed(name string) {
 	r.passed++
 	r.printWithCheck(r.fancy.Gray(name))
 }
 
-func (r *DetailedReporter) itIsPending(name string) {
+func (r *DetailedReporter) ItIsPending(name string) {
 	r.pending++
 	r.print(r.fancy.Cyan("- " + name))
 }
 
-func (r *DetailedReporter) itIsExcluded(name string) {
+func (r *DetailedReporter) ItIsExcluded(name string) {
 	r.excluded++
 	r.print(r.fancy.Yellow("- " + name))
 }
 
-func (r *DetailedReporter) begin() {
+func (r *DetailedReporter) Begin() {
 }
 
-func (r *DetailedReporter) end() {
+func (r *DetailedReporter) End() {
 	comp := fmt.Sprintf("%d tests complete", r.passed)
 	t := fmt.Sprintf("(%d ms)", r.totalExecutionTime/time.Millisecond)
 

--- a/reporting.go
+++ b/reporting.go
@@ -144,9 +144,9 @@ func (r *DetailedReporter) End() {
 	}
 
 	for i, failure := range r.failures {
-		fmt.Printf("  %d) %s:\n\n", i+1, failure.testName)
-		fmt.Printf("    %s\n", r.fancy.Red(failure.message))
-		for _, stackItem := range failure.stack {
+		fmt.Printf("  %d) %s:\n\n", i+1, failure.TestName)
+		fmt.Printf("    %s\n", r.fancy.Red(failure.Message))
+		for _, stackItem := range failure.Stack {
 			fmt.Printf("    %s\n", r.fancy.Gray(stackItem))
 		}
 	}

--- a/reporting_test.go
+++ b/reporting_test.go
@@ -19,44 +19,44 @@ type FakeReporter struct {
 	beginFlag, endFlag bool
 }
 
-func (r *FakeReporter) beginDescribe(name string) {
+func (r *FakeReporter) BeginDescribe(name string) {
 	r.describes = append(r.describes, name)
 }
 
-func (r *FakeReporter) endDescribe() {
+func (r *FakeReporter) EndDescribe() {
 	r.ends++
 }
 
-func (r *FakeReporter) failure(failure *Failure) {
+func (r *FakeReporter) Failure(failure *Failure) {
 	r.failures++
 }
 
-func (r *FakeReporter) itFailed(name string) {
+func (r *FakeReporter) ItFailed(name string) {
 	r.fails = append(r.fails, name)
 }
 
-func (r *FakeReporter) itPassed(name string) {
+func (r *FakeReporter) ItPassed(name string) {
 	r.passes = append(r.passes, name)
 }
 
-func (r *FakeReporter) itIsPending(name string) {
+func (r *FakeReporter) ItIsPending(name string) {
 	r.pending = append(r.pending, name)
 }
 
-func (r *FakeReporter) itIsExcluded(name string) {
+func (r *FakeReporter) ItIsExcluded(name string) {
 	r.excluded = append(r.excluded, name)
 }
 
-func (r *FakeReporter) itTook(duration time.Duration) {
+func (r *FakeReporter) ItTook(duration time.Duration) {
 	r.executionTime = duration
 	r.totalExecutionTime += duration
 }
 
-func (r *FakeReporter) begin() {
+func (r *FakeReporter) Begin() {
 	r.beginFlag = true
 }
 
-func (r *FakeReporter) end() {
+func (r *FakeReporter) End() {
 	r.endFlag = true
 }
 


### PR DESCRIPTION
When the `goblin.Reporter` interface had all private methods, it was not possible to make Reporter implementations under another package namespace. When exported, we can have third-party reporters.