### PR TITLE
Accept various types of messages in assertions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
- - 1.6.3
+ - 1.12
 notifications:
   email:
       - ionathan@gmail.com

--- a/assertions.go
+++ b/assertions.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 )
 
-// Assertion represents a fact stated about a source object. It contains the source object and function to call
+// Assertion represents a fact stated about a source object. It contains the
+// source object and function to call
 type Assertion struct {
 	src  interface{}
 	fail func(interface{})
@@ -28,43 +29,64 @@ func objectsAreEqual(a, b interface{}) bool {
 	return false
 }
 
-func formatMessages(messages ...string) string {
-	if len(messages) > 0 {
-		return ", " + strings.Join(messages, " ")
+// Format series of messages provided to an assertion.  Separate messages from
+// the preamble of assertion with a comma and concatenate messages using spaces.
+// Messages that are purely whitespace will be wrapped with square brackets, so
+// the developer can glean that something was actually reported in a message.
+func formatMessages(messages ...interface{}) string {
+	// Concatenate messages together.
+	var fm strings.Builder
+	for _, message := range messages {
+		fm.WriteString(" ")
+
+		// Format message then wrap with square brackets if only
+		// whitespace.
+		m := fmt.Sprintf("%v", message)
+		if strings.TrimSpace(m) == "" {
+			m = fmt.Sprintf("[%s]", m)
+		}
+		fm.WriteString(m)
 	}
-	return ""
+
+	if fm.Len() == 0 {
+		return ""
+	}
+	return "," + fm.String()
 }
 
 // Eql is a shorthand alias of Equal for convenience
-func (a *Assertion) Eql(dst interface{}) {
-	a.Equal(dst)
+func (a *Assertion) Eql(dst interface{}, messages ...interface{}) {
+	a.Equal(dst, messages)
 }
 
 // Equal takes a destination object and asserts that a source object and
 // destination object are equal to one another. It will fail the assertion and
 // print a corresponding message if the objects are not equivalent.
-func (a *Assertion) Equal(dst interface{}) {
+func (a *Assertion) Equal(dst interface{}, messages ...interface{}) {
 	if !objectsAreEqual(a.src, dst) {
-		a.fail(fmt.Sprintf("%#v %s %#v", a.src, "does not equal", dst))
+		a.fail(fmt.Sprintf("%#v %s %#v%s", a.src, "does not equal", dst,
+			formatMessages(messages...)))
 	}
 }
 
 // IsTrue asserts that a source is equal to true. Optional messages can be
 // provided for inclusion in the displayed message if the assertion fails. It
 // will fail the assertion if the source does not resolve to true.
-func (a *Assertion) IsTrue(messages ...string) {
+func (a *Assertion) IsTrue(messages ...interface{}) {
 	if !objectsAreEqual(a.src, true) {
-		message := fmt.Sprintf("%v %s%s", a.src, "expected false to be truthy", formatMessages(messages...))
-		a.fail(message)
+		a.fail(fmt.Sprintf("%v %s%s", a.src,
+			"expected false to be truthy",
+			formatMessages(messages...)))
 	}
 }
 
 // IsFalse asserts that a source is equal to false. Optional messages can be
 // provided for inclusion in the displayed message if the assertion fails. It
 // will fail the assertion if the source does not resolve to false.
-func (a *Assertion) IsFalse(messages ...string) {
+func (a *Assertion) IsFalse(messages ...interface{}) {
 	if !objectsAreEqual(a.src, false) {
-		message := fmt.Sprintf("%v %s%s", a.src, "expected true to be falsey", formatMessages(messages...))
-		a.fail(message)
+		a.fail(fmt.Sprintf("%v %s%s", a.src,
+			"expected true to be falsey",
+			formatMessages(messages...)))
 	}
 }

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -80,8 +80,8 @@ func TestMultipleDescribes(t *testing.T) {
 			})
 		})
 
-		g.Describe("Substraction", func() {
-			g.It("Should substract numbers ", func() {
+		g.Describe("Subtraction", func() {
+			g.It("Should subtract numbers", func() {
 				count++
 				sub := 5 - 5
 				g.Assert(sub).Equal(1)
@@ -103,8 +103,8 @@ func TestPending(t *testing.T) {
 
 		g.It("Should add numbers")
 
-		g.Describe("Substraction", func() {
-			g.It("Should substract numbers")
+		g.Describe("Subtraction", func() {
+			g.It("Should subtract numbers")
 		})
 
 	})
@@ -128,8 +128,8 @@ func TestExcluded(t *testing.T) {
 			g.Assert(sum).Equal(2)
 		})
 
-		g.Describe("Substraction", func() {
-			g.Xit("Should substract numbers", func() {
+		g.Describe("Subtraction", func() {
+			g.Xit("Should subtract numbers", func() {
 				count++
 				sub := 5 - 5
 				g.Assert(sub).Equal(1)
@@ -287,7 +287,7 @@ func TestFailOnError(t *testing.T) {
 	})
 
 	g.Describe("Errors", func() {
-		g.It("Should fail with structs ", func() {
+		g.It("Should fail with structs", func() {
 			var s struct{ error string }
 			s.error = "Error"
 			g.Fail(s)
@@ -327,12 +327,12 @@ func TestFailImmediately(t *testing.T) {
 	g := Goblin(&fakeTest)
 	reached := false
 	g.Describe("Errors", func() {
-		g.It("Should fail immediately for sync test ", func() {
+		g.It("Should fail immediately for sync test", func() {
 			g.Assert(false).IsTrue()
 			reached = true
 			g.Assert("foo").Equal("bar")
 		})
-		g.It("Should fail immediately for async test ", func(done Done) {
+		g.It("Should fail immediately for async test", func(done Done) {
 			go func() {
 				g.Assert(false).IsTrue()
 				reached = true
@@ -355,14 +355,14 @@ func TestAsync(t *testing.T) {
 		g.It("Should fail when Fail is called immediately", func(done Done) {
 			g.Fail("Failed")
 		})
-		g.It("Should fail when fail is called", func(done Done) {
+		g.It("Should fail when Fail is called", func(done Done) {
 			go func() {
 				time.Sleep(100 * time.Millisecond)
 				g.Fail("foo is not bar")
 			}()
 		})
 
-		g.It("Should fail if done receives a parameter ", func(done Done) {
+		g.It("Should fail if done receives a parameter", func(done Done) {
 			go func() {
 				time.Sleep(100 * time.Millisecond)
 				done("Error")

--- a/it_test.go
+++ b/it_test.go
@@ -104,7 +104,7 @@ func TestAfterEach(t *testing.T) {
 			g.Assert(after).Equal(0)
 		})
 
-		g.It("Should have called afterEach before this test ", func() {
+		g.It("Should have called afterEach before this test", func() {
 			g.Assert(after).Equal(1)
 		})
 	})


### PR DESCRIPTION
Expand all assertions to accept various types of messages to emit as
output when the expression evaluates to false.  This changes permits
unit tests to use any assertion call for returning a message instead of
just IsTrue() and IsFalse().

The change from accepting only strings to any value allows for
simplification of unit tests that just print the error string.

This allows replacing:
```go
if err != nil {
        g.Fail(err.Error())
}
```

With:
```go
g.Assert(err == nil).IsTrue(err)
```

The logic to format the messages into output relies upon fmt.Sprintf().
It simply concatenates the messages together with one exception:
messages that are only whitespace.  In this case, it wraps the
whitespace with square brackets to make it more obvious that a message
was provided albeit unseen.

Bump CI version of Go to 1.12 which is the oldest version still
supported by the Go developers.  It is also includes strings.Builder
which is needed by the new assertion message code.

Correct spelling and remove trailing spaces.