### PR TITLE
fix regex flag parsing #74

### DIFF
--- a/goblin.go
+++ b/goblin.go
@@ -189,11 +189,6 @@ func (xit *Xit) failed(msg string, stack []string) {
 func parseFlags() {
 	//Flag parsing
 	flag.Parse()
-	if *regexParam != "" {
-		runRegex = regexp.MustCompile(*regexParam)
-	} else {
-		runRegex = nil
-	}
 }
 
 var timeout = flag.Duration("goblin.timeout", 5*time.Second, "Sets default timeouts for all tests")
@@ -295,8 +290,27 @@ func (g *G) Xit(name string, h ...interface{}) {
 	}
 }
 
+func setRegex(param string) {
+	if param == "" {
+		return
+	}
+
+	isNotSet := runRegex == nil
+	if isNotSet {
+		runRegex = regexp.MustCompile(param)
+		return
+	}
+
+	isChanged := runRegex.String() != param
+	if isChanged {
+		runRegex = regexp.MustCompile(param)
+	}
+}
+
 func matchesRegex(value string) bool {
-	if runRegex != nil {
+	param := *regexParam
+	setRegex(param)
+	if param != "" {
 		return runRegex.MatchString(value)
 	}
 	return true

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -317,9 +317,6 @@ func TestRegex(t *testing.T) {
 	if fakeTest.Failed() {
 		t.Fatal("Failed")
 	}
-
-	// Reset the regex so other tests can run
-	runRegex = nil
 }
 
 func TestFailImmediately(t *testing.T) {

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -1,7 +1,9 @@
 package goblin
 
 import (
+	"bytes"
 	"os"
+	"os/exec"
 	"testing"
 	"time"
 )
@@ -430,6 +432,51 @@ func TestItTimeout(t *testing.T) {
 
 	})
 	if fakeTest.Failed() {
+		t.Fatal("Failed")
+	}
+}
+
+func TestItRegexExec(t *testing.T) {
+
+	cs := []string{"-test.run=TestHandleItRegexExec", "-goblin.run=TestsrunPass"}
+	cmd := exec.Command(os.Args[0], cs...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("Failed, error:%s", err)
+	}
+	_, errStr := string(stdout.Bytes()), string(stderr.Bytes())
+	if errStr != "" {
+		t.Fatalf("Failed, errorStr:%s", errStr)
+	}
+}
+
+func TestHandleItRegexExec(t *testing.T) {
+
+	g := Goblin(t)
+
+	counter := 0
+	g.Describe("TestItRegexExec Helper", func() {
+		g.It("TestsrunFail", func() {
+			counter++
+			g.Assert(counter).Equal(counter)
+		})
+
+		g.It("TestsrunPass", func() {
+			counter++
+			g.Assert(counter).Equal(counter)
+		})
+
+		g.It("TestsrunPass", func() {
+			counter++
+			g.Assert(counter).Equal(counter)
+		})
+	})
+
+	if *regexParam != "" && counter != 2 {
 		t.Fatal("Failed")
 	}
 }

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -346,7 +346,10 @@ func TestFailImmediately(t *testing.T) {
 
 func TestAsync(t *testing.T) {
 	fakeTest := testing.T{}
+
+	os.Args = append(os.Args, "-goblin.run=")
 	g := Goblin(&fakeTest)
+	parseFlags()
 
 	g.Describe("Async test", func() {
 		g.It("Should fail when Fail is called immediately", func(done Done) {

--- a/reporting_test.go
+++ b/reporting_test.go
@@ -108,7 +108,7 @@ func TestReportingTime(t *testing.T) {
 	g.Describe("One", func() {
 		g.AfterEach(func() {
 			//TODO: Make this an assertion
-			if int64(reporter.executionTime/time.Millisecond) < 5 || int64(reporter.executionTime/time.Millisecond) >= 6 {
+			if int64(reporter.executionTime/time.Millisecond) < 5 || int64(reporter.executionTime/time.Millisecond) > 6 {
 				t.FailNow()
 			}
 		})


### PR DESCRIPTION
Passed in flags like goblin.run are never parsed because the default testing package calls flag.Parse() before goblin calls flag.Parse(), which means the runRegex flag never gets set.

Resolves #74 

Test manually:
1) Make a new test file like flag_test.go
```
package goblin

import (
	"testing"
)

func TestFlagRegex(t *testing.T) {
	g := Goblin(t)

	g.Describe("Test", func() {
		g.It("Auth 1", func() {})
		g.It("Auth 2", func() {})
		g.It("Mismatched test", func() {})
	})
}

```
2) run `go test -timeout 30s -run ^TestFlagRegex -v -goblin.run=Auth`
3) the output will have `Auth 1` and `Auth 2`, but not `Mismatched test`


## Some exploration of the bug:

```
// Add this into the end of the Goblin() function 
fmt.Println("......", os.Args[1:], timeout, *regexParam, "[", runRegex, "]", *regexParam != "")
```


run `go test -run ^TestHandleItRegexExec -goblin.run="TestsrunPass"`
```
...... [-test.timeout=10m0s -test.run=^TestHandleItRegexExec -goblin.run=TestsrunPass] 5s TestsrunPass [ <nil> ] true

  TestItRegexExec Helper
    ✓ TestsrunFail
    ✓ TestsrunPass
    ✓ TestsrunPass


 3 tests complete (0 ms)
--- FAIL: TestHandleItRegexExec (0.00s)
    goblin_test.go:480: Failed
FAIL
exit status 1
FAIL	_/Users/sockol/Desktop/Projects/goblin	0.293s
```

So this test doesnt parse the "runRegex" since flag.Parse() has been called 
```
if !flag.Parsed() {
	parseFlags() // never runs, never sets "runRegex"
}
```

If we adjust the condition to be 
```
func Goblin(t *testing.T, arguments ...string) *G {
	parseFlags()
	...

func parseFlags() {
	//Flag parsing
	if !flag.Parsed() {
		flag.Parse()
	}
	if *regexParam != "" {
		runRegex = regexp.MustCompile(*regexParam)
	} else {
		runRegex = nil
	}
}
```
The command works as expected 

```
 ~/De/P/goblin  on master *10 !2  go test -run ^TestHandleItRegexExec -goblin.run="TestsrunPass"
...... [-test.timeout=10m0s -test.run=^TestHandleItRegexExec -goblin.run=TestsrunPass] 5s TestsrunPass [ TestsrunPass ] true

  TestItRegexExec Helper
    ✓ TestsrunPass
    ✓ TestsrunPass


 2 tests complete (0 ms)
PASS
ok  	_/Users/sockol/Desktop/Projects/goblin	0.135s
```

But the tests break - the new args passed into the "TestRegex" test are not parsed, `[ runRegex]` is not set

```
......  [-test.timeout=10m0s -goblin.run=matches] 5s  [ <nil> ] false

  Test
    1) Doesn't match regex
    ✓ It matches regex
    ✓ It also matches


 2 tests complete (0 ms)
 1 tests failed:

  1) Test Doesn't match regex:

    Regex shouldn't match
    	/Users/sockol/Desktop/Projects/goblin/goblin_test.go:312 +0x42
    	/Users/sockol/Desktop/Projects/goblin/goblin.go:231 +0x27
    	/Users/sockol/Desktop/Projects/goblin/goblin.go:231 +0x3e7
--- FAIL: TestRegex (0.00s)
	goblin_test.go:320: Failed
```
