### PR TITLE
Add new github.com/franela/goblin module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/franela/goblin
+
+go 1.14


### PR DESCRIPTION
From go version 1.11 Go natively supports modules for dependency
management.

I created a local project and imported goblin as a module using `github.com/matipan/golbin` to validate it works. After that I renamed the module to franela/goblin. Once its merged we can create tags to point at specific versions