### PR TITLE
Replace travis with github actions and migrate to Go modules

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,30 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+
+    - name: Tests
+      run: go test -v .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: go
-go:
- - 1.12
-notifications:
-  email:
-      - ionathan@gmail.com
-      - marcosnils@gmail.com

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/franela/goblin
+
+go 1.14


### PR DESCRIPTION
After being acquired travis CI is fading away and soon all free pipelines will no longer be supported. Github actions is a good enough (and easy enough) alternative to it.

From go version 1.11 Go natively supports modules for dependency
management.

I created a local project and imported goblin as a module using github.com/matipan/golbin to validate it works. After that I renamed the module to franela/goblin. Once its merged we can create tags to point at specific versions