### PR TITLE
feat(assertions): add nil and zero assertions

### DIFF
--- a/assertions.go
+++ b/assertions.go
@@ -90,3 +90,47 @@ func (a *Assertion) IsFalse(messages ...interface{}) {
 			formatMessages(messages...)))
 	}
 }
+
+// IsNil asserts that source is nil.
+func (a *Assertion) IsNil(messages ...interface{}) {
+	if !objectsAreEqual(a.src, nil) {
+		message := fmt.Sprintf("%v %s%v", a.src, "expected to be nil", formatMessages(messages...))
+
+		a.fail(message)
+	}
+}
+
+// IsNotNil asserts that source is not nil.
+func (a *Assertion) IsNotNil(messages ...interface{}) {
+	if objectsAreEqual(a.src, nil) {
+		message := fmt.Sprintf("%v %s%v", a.src, "is nil", formatMessages(messages...))
+
+		a.fail(message)
+	}
+}
+
+// IsZero asserts that source is a zero value for its respective type.
+// If it is a structure, for example, all of its fields must have their
+// respective zero value: "" for strings, 0 for int, etc. Slices, arrays
+// and maps are only considered zero if they are nil. To check if these
+// type of values are empty or not, use the len() from the data source
+// with IsZero(). Example: g.Assert(len(list)).IsZero().
+func (a *Assertion) IsZero(messages ...interface{}) {
+	valueOf := reflect.ValueOf(a.src)
+
+	if !valueOf.IsZero() {
+		message := fmt.Sprintf("%#v %s%v", a.src, "is not a zero value", formatMessages(messages...))
+
+		a.fail(message)
+	}
+}
+
+// IsNotZero asserts the contrary of IsZero.
+func (a *Assertion) IsNotZero(messages ...interface{}) {
+	valueOf := reflect.ValueOf(a.src)
+
+	if valueOf.IsZero() {
+		message := fmt.Sprintf("%#v %s%v", a.src, "is a zero value", formatMessages(messages...))
+		a.fail(message)
+	}
+}

--- a/assertions_test.go
+++ b/assertions_test.go
@@ -145,3 +145,143 @@ func TestIsTrueWithMessage(t *testing.T) {
 	verifier.Verify(t)
 	verifier.VerifyMessage(t, "false expected false to be truthy, true is not false")
 }
+
+func TestIsNil(t *testing.T) {
+	verifier := AssertionVerifier{ShouldPass: true}
+	a := Assertion{src: nil, fail: verifier.FailFunc}
+	a.IsNil()
+	verifier.Verify(t)
+
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: struct{}{}, fail: verifier.FailFunc}
+	a.IsNil()
+	verifier.Verify(t)
+}
+
+func TestIsNilWithMessage(t *testing.T) {
+	verifier := AssertionVerifier{ShouldPass: false}
+	a := Assertion{src: struct{}{}, fail: verifier.FailFunc}
+	a.IsNil("value is not nil")
+	verifier.Verify(t)
+	verifier.VerifyMessage(t, "{} expected to be nil, value is not nil")
+}
+
+func TestIsNotNil(t *testing.T) {
+	verifier := AssertionVerifier{ShouldPass: true}
+	a := Assertion{src: 1, fail: verifier.FailFunc}
+	a.IsNotNil()
+	verifier.Verify(t)
+
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: nil, fail: verifier.FailFunc}
+	a.IsNotNil()
+	verifier.Verify(t)
+}
+
+func TestIsNotNilWithMessage(t *testing.T) {
+	verifier := AssertionVerifier{ShouldPass: false}
+	a := Assertion{src: nil, fail: verifier.FailFunc}
+	a.IsNotNil("value should not be nil")
+	verifier.Verify(t)
+	verifier.VerifyMessage(t, "<nil> is nil, value should not be nil")
+}
+
+func TestIsZeroForStructs(t *testing.T) {
+	source := struct{ Name string }{}
+	verifier := AssertionVerifier{ShouldPass: true}
+	a := Assertion{src: source, fail: verifier.FailFunc}
+	a.IsZero()
+	verifier.Verify(t)
+
+	source = struct{ Name string }{Name: "Person"}
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: source, fail: verifier.FailFunc}
+	a.IsZero()
+	verifier.Verify(t)
+}
+
+func TestIsZeroForInt(t *testing.T) {
+	verifier := AssertionVerifier{ShouldPass: true}
+	a := Assertion{src: 0, fail: verifier.FailFunc}
+	a.IsZero()
+	verifier.Verify(t)
+
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: 1, fail: verifier.FailFunc}
+	a.IsZero()
+	verifier.Verify(t)
+}
+
+func TestIsZeroForFloat(t *testing.T) {
+	verifier := AssertionVerifier{ShouldPass: true}
+	a := Assertion{src: 0.0, fail: verifier.FailFunc}
+	a.IsZero()
+	verifier.Verify(t)
+
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: 5.1, fail: verifier.FailFunc}
+	a.IsZero()
+	verifier.Verify(t)
+}
+
+func TestIsZeroWithMessage(t *testing.T) {
+	source := struct {
+		Name string
+	}{
+		Name: "Person",
+	}
+	verifier := AssertionVerifier{ShouldPass: false}
+	a := Assertion{src: source, fail: verifier.FailFunc}
+	a.IsZero("should be zero")
+	verifier.Verify(t)
+	message := "struct { Name string }{Name:\"Person\"} is not a zero value, should be zero"
+	verifier.VerifyMessage(t, message)
+}
+
+func TestIsNotZeroForStructs(t *testing.T) {
+	source := struct{ Name string }{Name: "Person"}
+	verifier := AssertionVerifier{ShouldPass: true}
+	a := Assertion{src: source, fail: verifier.FailFunc}
+	a.IsNotZero()
+	verifier.Verify(t)
+
+	source = struct{ Name string }{}
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: source, fail: verifier.FailFunc}
+	a.IsNotZero()
+	verifier.Verify(t)
+}
+
+func TestIsNotZeroForInt(t *testing.T) {
+	verifier := AssertionVerifier{ShouldPass: true}
+	a := Assertion{src: 1, fail: verifier.FailFunc}
+	a.IsNotZero()
+	verifier.Verify(t)
+
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: 0, fail: verifier.FailFunc}
+	a.IsNotZero()
+	verifier.Verify(t)
+}
+
+func TestIsNotZeroForFloat(t *testing.T) {
+	verifier := AssertionVerifier{ShouldPass: true}
+	a := Assertion{src: 0.1, fail: verifier.FailFunc}
+	a.IsNotZero()
+	verifier.Verify(t)
+
+	verifier = AssertionVerifier{ShouldPass: false}
+	a = Assertion{src: 0.0, fail: verifier.FailFunc}
+	a.IsNotZero()
+	verifier.Verify(t)
+}
+
+func TestIsNotZeroWithMessage(t *testing.T) {
+	source := struct{ Name string }{}
+	verifier := AssertionVerifier{ShouldPass: false}
+	a := Assertion{src: source, fail: verifier.FailFunc}
+	a.IsNotZero("should not be zero")
+	verifier.Verify(t)
+	message := "struct { Name string }{Name:\"\"} is a zero value, should not be zero"
+	verifier.VerifyMessage(t, message)
+}

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -502,3 +502,129 @@ func TestItTimeout(t *testing.T) {
 		t.Fatal("Failed")
 	}
 }
+
+func TestIsNilAndIsNotNil(t *testing.T) {
+	fakeTest := testing.T{}
+	g := Goblin(&fakeTest)
+
+	g.Describe("Test for IsNil", func() {
+		g.It("Should assert successfully with nil value", func() {
+			g.Assert(nil).IsNil()
+		})
+	})
+
+	g.Describe("Test for IsNotNil", func() {
+		g.It("Should assert successfully with not nil value", func() {
+			g.Assert(struct{}{}).IsNotNil()
+		})
+	})
+
+	if fakeTest.Failed() {
+		t.Fatal("Failed")
+	}
+
+	g.Describe("Test for IsNil with failed assertion", func() {
+		g.It("Should fail", func() {
+			g.Assert(100).IsNil()
+		})
+	})
+
+	g.Describe("Test for IsNotNil with failed assertion", func() {
+		g.It("Should fail", func() {
+			g.Assert(nil).IsNotNil()
+		})
+	})
+
+	if !fakeTest.Failed() {
+		t.Fatal("Failed")
+	}
+}
+
+func TestIsZeroAndIsNotZero(t *testing.T) {
+	fakeTest := testing.T{}
+	g := Goblin(&fakeTest)
+
+	g.Describe("Test for IsZero", func() {
+		g.It("Should assert successfully with int zero value", func() {
+			g.Assert(0).IsZero()
+		})
+
+		g.It("Should assert successfully with float zero value", func() {
+			g.Assert(0.0).IsZero()
+		})
+
+		g.It("Should assert successfully with string zero value", func() {
+			g.Assert("").IsZero()
+		})
+
+		g.It("Should assert successfully with struct zero value", func() {
+			g.Assert(struct{}{}).IsZero()
+		})
+
+		g.It("Should assert successfully with struct field with zero value", func() {
+			g.Assert(struct{ value int }{value: 0}).IsZero()
+		})
+	})
+
+	g.Describe("Test for IsNotZero", func() {
+		g.It("Should assert successfully with int not zero value", func() {
+			g.Assert(1).IsNotZero()
+		})
+
+		g.It("Should assert successfully with float  not zero value", func() {
+			g.Assert(0.5).IsNotZero()
+		})
+
+		g.It("Should assert successfully with string not zero value", func() {
+			g.Assert("ABC").IsNotZero()
+		})
+
+		g.It("Should assert successfully with struct not zero value", func() {
+			g.Assert(struct{ value int }{value: 1}).IsNotZero()
+		})
+	})
+
+	if fakeTest.Failed() {
+		t.Fatal("Failed")
+	}
+
+	g.Describe("Test for IsZero with failed assertion", func() {
+		g.It("Should fail", func() {
+			g.Assert(100).IsZero()
+		})
+
+		g.It("Should fail", func() {
+			g.Assert(1.0).IsZero()
+		})
+
+		g.It("Should fail", func() {
+			g.Assert("A").IsZero()
+		})
+
+		g.It("Should fail", func() {
+			g.Assert(struct{ value int }{value: 1}).IsZero()
+		})
+	})
+
+	g.Describe("Test for IsNotZero with failed assertion", func() {
+		g.It("Should fail", func() {
+			g.Assert(0).IsNotZero()
+		})
+
+		g.It("Should fail", func() {
+			g.Assert(0.0).IsNotZero()
+		})
+
+		g.It("Should fail", func() {
+			g.Assert("").IsNotZero()
+		})
+
+		g.It("Should fail", func() {
+			g.Assert(struct{}{}).IsNotZero()
+		})
+	})
+
+	if !fakeTest.Failed() {
+		t.Fatal("Failed")
+	}
+}


### PR DESCRIPTION
This pull request implements the following assertions:

`IsNil` that helps avoiding `Assert(value != nil).IsTrue()`.
`IsNotNil`
`IsZero` whats is specially useful to assert that a struct is empty.
`IsNotZero`