### PR TITLE
adds failNow to allow using testify/require

### DIFF
--- a/goblin.go
+++ b/goblin.go
@@ -370,6 +370,10 @@ func (g *G) Fail(error interface{}) {
 	g.errorCommon(message, true)
 }
 
+func (g *G) FailNow() {
+	g.t.FailNow()
+}
+
 func (g *G) Failf(format string, args ...interface{}) {
 	message := fmt.Sprintf(format, args...)
 	g.errorCommon(message, true)


### PR DESCRIPTION
This allows using testity requires:

```go
require.True(g, someVariable)
```