### PR TITLE
Fixed a few race conditions

### DIFF
--- a/it_test.go
+++ b/it_test.go
@@ -161,7 +161,7 @@ func TestNestedAfterEach(t *testing.T) {
 				g.Assert(after).Equal(0)
 			})
 
-			g.It("Should have called all the registered aftearEach", func() {
+			g.It("Should have called all the registered afterEach", func() {
 				g.Assert(after).Equal(2)
 			})
 		})

--- a/race_test.go
+++ b/race_test.go
@@ -1,0 +1,46 @@
+// +build race
+
+package goblin
+
+import (
+	"testing"
+	"time"
+)
+
+func TestG_It_AsyncDone_Race(t *testing.T) {
+	fakeTest := testing.T{}
+	g := Goblin(&fakeTest)
+
+	g.Describe("Async test", func() {
+		g.It("Should not create a data race if done() is called multiple times", func(done Done) {
+			go func() {
+				time.Sleep(100 * time.Millisecond)
+				done()
+				done()
+			}()
+		})
+	})
+}
+
+func TestG_It_Fail_Race(t *testing.T) {
+	g := Goblin(new(testing.T))
+
+	g.Describe("Synchronous test", func() {
+		g.It("Should not create a data race on fail", func() {
+			g.Fail("Failed")
+		})
+	})
+}
+
+func TestG_It_Assert_Race(t *testing.T) {
+	g := Goblin(new(testing.T))
+	g.SetReporter(Reporter(new(FakeReporter)))
+
+	g.Describe("Should not create a data race", func() {
+		g.It("Should fail", func() {
+			g.Assert(0).Equal(1)
+		})
+		g.It("Should pass", func() {
+		})
+	})
+}


### PR DESCRIPTION
## List of changes
- Structures
  - Added field It.failureMu of type sync.RWMutex
  - Added field DetailedReporter.executionTimeMu of type sync.RWMutex
  - Added field FakeReporter.executionTimeMu of type sync.RWMutex
- Made the methods accessing the fields protected by the new mutexes Lock/RLock the mutex before accessing it

## Why?
`go test -race` on this package revealed multiple race conditions, which should be fixed by this PR.

Now, the default tests of this package pass with the `-race` flag without issues.