### PR TITLE
Added Timeout() for Describe and Top Level

### DIFF
--- a/goblin_test.go
+++ b/goblin_test.go
@@ -465,7 +465,7 @@ func TestTimeout(t *testing.T) {
 	parseFlags()
 	g := Goblin(&fakeTest)
 
-	g.Describe("Test", func() {
+	g.Describe("Test arg", func() {
 		g.It("Should fail if test exceeds the specified timeout with sync test", func() {
 			time.Sleep(100 * time.Millisecond)
 		})
@@ -476,6 +476,71 @@ func TestTimeout(t *testing.T) {
 		})
 	})
 
+	if !fakeTest.Failed() {
+		t.Fatal("Failed")
+	}
+}
+
+func TestTopLevelTimeout(t *testing.T) {
+	fakeTest := testing.T{}
+	os.Args = append(os.Args, "-goblin.timeout=10ms")
+	parseFlags()
+	g := Goblin(&fakeTest)
+
+	g.Timeout(20 * time.Millisecond)
+
+	g.Describe("Test", func() {
+		g.It("Should override default timeout with sync test", func() {
+			time.Sleep(15 * time.Millisecond)
+		})
+
+		g.It("Should override default timeout with async test", func(done Done) {
+			time.Sleep(15 * time.Millisecond)
+			done()
+		})
+	})
+	if fakeTest.Failed() {
+		t.Fatal("Failed")
+	}
+}
+
+func TestDescribeTimeout(t *testing.T) {
+	fakeTest := testing.T{}
+	os.Args = append(os.Args, "-goblin.timeout=10ms")
+	parseFlags()
+	g := Goblin(&fakeTest)
+
+	g.Describe("Test 0", func() {
+		g.Timeout(20 * time.Millisecond)
+		g.It("Should override default timeout with sync test", func() {
+			time.Sleep(15 * time.Millisecond)
+		})
+
+		g.It("Should override default timeout with async test", func() {
+			time.Sleep(15 * time.Millisecond)
+		})
+
+	})
+	if fakeTest.Failed() {
+		t.Fatal("Failed")
+	}
+
+	g.Describe("Test 1", func() {
+		g.It("Should revert for different Describe with sync test", func() {
+			time.Sleep(15 * time.Millisecond)
+		})
+
+	})
+	if !fakeTest.Failed() {
+		t.Fatal("Failed")
+	}
+
+	g.Describe("Test 2", func() {
+		g.It("Should revert for different Describe with async test", func() {
+			time.Sleep(15 * time.Millisecond)
+		})
+
+	})
 	if !fakeTest.Failed() {
 		t.Fatal("Failed")
 	}


### PR DESCRIPTION
## What was the previous behavior
Previously, calling `G.Timeout()` inside a _Describe_ or in the _top level test function_ resulted in the following error:
`panic: runtime error: invalid memory address or nil pointer dereference [recovered]`
This was because of this piece of code:
```go
func (g *G) Timeout(time time.Duration) {
	g.timeout = time
	g.timer.Reset(time) // <- g.timer not defined outside of an It block
}
```

## Which behavior is this PR bringing

- When inside an _It_ block, nothing changes
- When inside a _Describe_ block, sets the timeout to the given value, except when overridden inside an _It_ block (only affect the _It_ inside which is the `g.Timeout()`)
- When outside of any _Describe_ or _It_ it is applied to every _It_ block unless overriden in the _It_ or in the parent _Describe_.

`g.Timeout()` can be called multiple times in which case the given value applies until a new `g.Timeout()` is encountered in the same or an higher scope.

## What would have been another valid behavior ?

It could be coherent that calling `g.Timeout` inside a _Describe_ sets a maximum execution time for the whole _Describe_, and not for every _It_ inside it. The same way, setting the timeout in the _top level function_ could set a global time for all of the _Describes_ instead of a time per _It_.

## Which improvements could be made ?

The test suite for the timeouts is pretty bad, as it calls `time.Sleep()` many times, which makes the testing slow, and it could be interesting to think of a way to mock the `Sleep` calls.
