### PR TITLE
Concurrency race

### DIFF
--- a/goblin.go
+++ b/goblin.go
@@ -185,9 +185,11 @@ func (xit *Xit) failed(msg string, stack []string) {
 	xit.failure = nil
 }
 
+var once sync.Once
+
 func parseFlags() {
 	//Flag parsing
-	flag.Parse()
+	once.Do(flag.Parse)
 	if *regexParam != "" {
 		runRegex = regexp.MustCompile(*regexParam)
 	} else {

--- a/race_test.go
+++ b/race_test.go
@@ -42,3 +42,9 @@ func TestG_It_Assert_Race(t *testing.T) {
 		})
 	})
 }
+
+func TestG_Concurrency_Race(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		go Goblin(nil)
+	}
+}

--- a/race_test.go
+++ b/race_test.go
@@ -45,6 +45,12 @@ func TestG_It_Assert_Race(t *testing.T) {
 
 func TestG_Concurrency_Race(t *testing.T) {
 	for i := 0; i < 1000; i++ {
-		go Goblin(nil)
+		gob := Goblin(t)
+		go func(g *G) {
+			g.Describe("Should not create a data race", func() {
+				g.It("Should pass", func() {
+				})
+			})
+		}(gob)
 	}
 }


### PR DESCRIPTION
### Bug

When using Goblin in Go table tests run in parallel occasionally will get the following error, a large dump of data/stack and failed test:
```
fatal error: concurrent map writes
...
```

### Why

When using Goblin in parallel it makes multiple calls to `flag.Parse()` which somewhere does a map assignment without a mutex. `flag.Parse()` is not meant to be called multiple times like this.

### Solution

Wrapping the call `flag.Parse()` in `sync.Once.Do()` so it only gets called once per instance of Goblin and resolves the issue. 