### PR TITLE
fix: Concurrency race when running in parallel

### DIFF
--- a/goblin.go
+++ b/goblin.go
@@ -186,15 +186,13 @@ func (xit *Xit) failed(msg string, stack []string) {
 }
 
 func parseFlags() {
-	doParseOnce.Do(func() {
-		//Flag parsing
-		flag.Parse()
-		if *regexParam != "" {
-			runRegex = regexp.MustCompile(*regexParam)
-		} else {
-			runRegex = nil
-		}
-	})
+	//Flag parsing
+	flag.Parse()
+	if *regexParam != "" {
+		runRegex = regexp.MustCompile(*regexParam)
+	} else {
+		runRegex = nil
+	}
 }
 
 var doParseOnce sync.Once
@@ -204,7 +202,10 @@ var regexParam = flag.String("goblin.run", "", "Runs only tests which match the 
 var runRegex *regexp.Regexp
 
 func Goblin(t *testing.T, arguments ...string) *G {
-	parseFlags()
+	doParseOnce.Do(func() {
+		parseFlags()
+	})
+
 	g := &G{t: t, timeout: *timeout}
 	var fancy TextFancier
 	if *isTty {

--- a/goblin.go
+++ b/goblin.go
@@ -186,15 +186,18 @@ func (xit *Xit) failed(msg string, stack []string) {
 }
 
 func parseFlags() {
-	//Flag parsing
-	flag.Parse()
-	if *regexParam != "" {
-		runRegex = regexp.MustCompile(*regexParam)
-	} else {
-		runRegex = nil
-	}
+	doParseOnce.Do(func() {
+		//Flag parsing
+		flag.Parse()
+		if *regexParam != "" {
+			runRegex = regexp.MustCompile(*regexParam)
+		} else {
+			runRegex = nil
+		}
+	})
 }
 
+var doParseOnce sync.Once
 var timeout = flag.Duration("goblin.timeout", 5*time.Second, "Sets default timeouts for all tests")
 var isTty = flag.Bool("goblin.tty", true, "Sets the default output format (color / monochrome)")
 var regexParam = flag.String("goblin.run", "", "Runs only tests which match the supplied regex")

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -627,4 +628,33 @@ func TestIsZeroAndIsNotZero(t *testing.T) {
 	if !fakeTest.Failed() {
 		t.Fatal("Failed")
 	}
+}
+
+func TestParseFlags(t *testing.T) {
+	wg := new(sync.WaitGroup)
+	const cnt = 2
+
+	wg.Add(cnt)
+	for i := 0; i < cnt; i++ {
+		go func() {
+			parseFlags()
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestGoblinConcurrence(t *testing.T) {
+	wg := new(sync.WaitGroup)
+	const cnt = 2
+
+	wg.Add(cnt)
+	for i := 0; i < cnt; i++ {
+		go func() {
+			Goblin(t)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }

--- a/goblin_test.go
+++ b/goblin_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 )
@@ -628,33 +627,4 @@ func TestIsZeroAndIsNotZero(t *testing.T) {
 	if !fakeTest.Failed() {
 		t.Fatal("Failed")
 	}
-}
-
-func TestParseFlags(t *testing.T) {
-	wg := new(sync.WaitGroup)
-	const cnt = 2
-
-	wg.Add(cnt)
-	for i := 0; i < cnt; i++ {
-		go func() {
-			parseFlags()
-			wg.Done()
-		}()
-	}
-
-	wg.Wait()
-}
-
-func TestGoblinConcurrence(t *testing.T) {
-	wg := new(sync.WaitGroup)
-	const cnt = 2
-
-	wg.Add(cnt)
-	for i := 0; i < cnt; i++ {
-		go func() {
-			Goblin(t)
-			wg.Done()
-		}()
-	}
-	wg.Wait()
 }

--- a/race_test.go
+++ b/race_test.go
@@ -1,6 +1,7 @@
 package goblin
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -41,4 +42,19 @@ func TestG_It_Assert_Race(t *testing.T) {
 		g.It("Should pass", func() {
 		})
 	})
+}
+
+func TestG_Parallel_New_Goblin(t *testing.T) {
+	wg := new(sync.WaitGroup)
+	const cnt = 2
+
+	wg.Add(cnt)
+	for i := 0; i < cnt; i++ {
+		go func() {
+			Goblin(new(testing.T))
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
Use sync.Once to init flag variables.

fix: #98 #99