### PR TITLE
feat: add the ability to skip test suites, hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ Goblin provides several different methods of marking tests to be skipped.
 - `g.SkipIf(...)` - skips all following tests if all passed args can be coerced
   to `true` (ish), also can take `func () bool` as an argument
 
+If all the tests within a suite are skipped, the `Before`, `After`, etc., hooks
+will not be run, which is convenient for suites that conditionally skip based on
+availability of external services.
+
 ```go
 package foobar
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/shakefu/goblin
+module github.com/franela/goblin
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/franela/goblin
+module github.com/shakefu/goblin
 
-go 1.14
+go 1.16


### PR DESCRIPTION
- Adds `Skip`, `SkipIf`, and `Resume` methods
- Skips `Before`, `After`, et. al., hooks when there are no tests to actually run
- Adds tests for skipping
- Updates tests with nonsense math to pass linting
- Updates to pass linting (Go standard)
- Updates module to Go 1.16 (may not be desired upstream?)
- Documents skipping functionality
